### PR TITLE
Reformat glossary for better readability

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,15 +1,17 @@
 # *Autonomicon* Glossary
 
-A glossary of terms used by and within NAF.  If you'd like to contribute to, or see revisions to some of these terms, discussion occurs in Network Automation Forum Slack in channel #doc-autonomicon.
+A glossary of terms used by and within NAF. If you'd like to contribute to, or see revisions to some of these terms, discussion occurs in Network Automation Forum Slack in channel #doc-autonomicon.
 
-Automation
-: software or other tooling designed to complete a task with no human intervention
+---
 
-Idempotent
-: a process or task that can be run multiple times and always reach the desired outcome
+**Automation**
+> Software or other tooling designed to complete a task with no human intervention
 
-Orchestration
-: software or other tooling designed to complete a series of tasks with no human intervention in a workflow based on a defined set of inputs
+**Idempotent**
+> A process or task that can be run multiple times and always reach the desired outcome
 
-Workflow
-: a series of ordered tasks, with potentially conditional execution, designed to complete a work process with minimal or no human intervention
+**Orchestration**
+> Software or other tooling designed to complete a series of tasks with no human intervention in a workflow based on a defined set of inputs
+
+**Workflow**
+> A series of ordered tasks, with potentially conditional execution, designed to complete a work process with minimal or no human intervention


### PR DESCRIPTION
The formatting of the glossary could be better in my opinion, I took the liberty to change that, so that future contributions can be already styled nicely.
Hope you like it.

This is how it would look like with my changes:
![image](https://github.com/Network-Automation-Forum/autonomicon/assets/55749236/172a8eb9-7870-471a-8697-d832c9c85406)

Like this on github:
![image](https://github.com/Network-Automation-Forum/autonomicon/assets/55749236/1fe65d37-f7cb-49d6-a1e7-3695823c2faa)

And something like this if the open mkdocs-material PR is accepted:
![image](https://github.com/Network-Automation-Forum/autonomicon/assets/55749236/0ce3ca2f-b22a-45c3-8304-fc0ff717a82c)

This is before:
![image](https://github.com/Network-Automation-Forum/autonomicon/assets/55749236/c4793dba-516b-4b27-aad8-6f7dc675869e)
