### PR TITLE
Adds SoT, SoR, SoO.

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -13,5 +13,16 @@ A glossary of terms used by and within NAF. If you'd like to contribute to, or s
 **Orchestration**
 > Software or other tooling designed to complete a series of tasks with no human intervention in a workflow based on a defined set of inputs
 
+**System of Origin (SoO)**
+> The system that users interact with to create new data points. It is sometimes the SoR, but is always tightly coupled to the business process that manages the data within a domain.
+
+**System of Record (SoR)**
+> This is the primary reference point that is authoritative for a particular data domain.
+
+**Source of Truth (SOT)**
+> The single aggregated state representing holistic network automation. Often integrates or incorporates SoR data and offers additional relationships[^1] between data across data domains.
+
 **Workflow**
 > A series of ordered tasks, with potentially conditional execution, designed to complete a work process with minimal or no human intervention
+
+[^1]: Such as relationship with interfaces and IP addresses that may not exist in a single SoR.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,9 @@ nav:
 repo_url: https://github.com/Network-Automation-Forum/autonomicon
 repo_name: Network-Automation-Forum/autonomicon
 
+markdown_extensions:
+  - footnotes
+
 theme:
   name: material
   logo: img/NAF.png


### PR DESCRIPTION
Adds SOT, SoO, and SoR definitions.

This also adds footnotes to help with examples. Could maybe look for annotation instead if desired. https://squidfunk.github.io/mkdocs-material/reference/footnotes/