### PR TITLE
Disabled package mode for poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "lexicon / glossary for \"standard\" and/or common network automat
 authors = ["Network Automation Community"]
 license = "CC0 1.0 Universal"
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Warning: The current project could not be installed: No file/folder found for package autonomicon
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
In a future version of Poetry this warning will become an error!